### PR TITLE
Update to Bacting 0.3.3

### DIFF
--- a/src/pybacting/api.py
+++ b/src/pybacting/api.py
@@ -19,7 +19,7 @@ __all__ = [
 ]
 
 WORKSPACE = "."
-VERSION = "0.3.1"
+VERSION = "0.3.3"
 
 # The ones marked with "no" can't be loaded because they are POM-only
 # artifacts. See the excellent explanation given by @ctrueden why at:

--- a/src/pybacting/api.py
+++ b/src/pybacting/api.py
@@ -8,14 +8,19 @@ __all__ = [
     "biojava",
     "bridgedb",
     "cdk",
+    "doi",
+    "duckduckgo",
     "excel",
     "inchi",
     "opsin",
     "oscar",
     "pubchem",
+    "pubmed",
     "qudt",
     "rdf",
+    "wikidata",
     "xml",
+    "zenodo",
 ]
 
 WORKSPACE = "."
@@ -28,8 +33,10 @@ endpoints = (
     # f"io.github.egonw.bacting:managers-semweb:{VERSION}", # no
     f"io.github.egonw.bacting:bacting-core:{VERSION}",
     f"io.github.egonw.bacting:managers-cdk:{VERSION}",
+    f"io.github.egonw.bacting:net.bioclipse.managers.duckduckgo:{VERSION}",
     f"io.github.egonw.bacting:managers-inchi:{VERSION}",
     f"io.github.egonw.bacting:managers-pubchem:{VERSION}",
+    f"io.github.egonw.bacting:net.bioclipse.managers.pubmed:{VERSION}",
     f"io.github.egonw.bacting:managers-xml:{VERSION}",
     f"io.github.egonw.bacting:managers-rdf:{VERSION}",
     # f"io.github.egonw.bacting:managers-bioinfo:{VERSION}", # no
@@ -40,6 +47,9 @@ endpoints = (
     f"io.github.egonw.bacting:managers-opsin:{VERSION}",
     f"io.github.egonw.bacting:managers-biojava:{VERSION}",
     f"io.github.egonw.bacting:managers-bridgedb:{VERSION}",
+    f"io.github.egonw.bacting:net.bioclipse.managers.wikidata:{VERSION}",
+    f"io.github.egonw.bacting:net.bioclipse.managers.doi:{VERSION}",
+    f"io.github.egonw.bacting:managers-zenodo:{VERSION}",
 )
 config.endpoints.extend(endpoints)
 
@@ -101,3 +111,23 @@ biojava = biojava_cls(WORKSPACE)
 qudt_cls = jimport("net.bioclipse.managers.QUDTManager")
 qudt = qudt_cls(WORKSPACE)
 """The quantity conversion manager from Bacting."""
+
+pubmed_cls = jimport("net.bioclipse.managers.PubmedManager")
+pubmed = pubmed_cls(WORKSPACE)
+"""The Pubmed manager from Bacting."""
+
+wikidata_cls = jimport("net.bioclipse.managers.WikidataManager")
+wikidata = wikidata_cls(WORKSPACE)
+"""The Wikidata manager from Bacting."""
+
+doi_cls = jimport("net.bioclipse.managers.DOIManager")
+doi = doi_cls(WORKSPACE)
+"""The Digital Object Identifier manager from Bacting."""
+
+zenodo_cls = jimport("net.bioclipse.managers.ZenodoManager")
+zenodo = zenodo_cls(WORKSPACE)
+"""The Zenodo manager from Bacting."""
+
+duckduckgo_cls = jimport("net.bioclipse.managers.DuckDuckGoManager")
+duckduckgo = duckduckgo_cls(WORKSPACE)
+"""The DuckDuckGo manager from Bacting."""


### PR DESCRIPTION
And made some managers available which were not yet.

Did I forget to do something?

Fails on an old Sphinx version (again)?

```
Failed to read intersphinx_mapping[https://docs.python.org/3/], ignored: SphinxWarning('The pre-Sphinx 1.0 \'intersphinx_mapping\' format is deprecated and will be removed in Sphinx 8. Update to the current format as described in the documentation. Hint: "intersphinx_mapping = {\'<name>\': (\'[https://docs.python.org/3/\](https://docs.python.org/3//)', None)}".https://www.sphinx-doc.org/en/master/usage/extensions/intersphinx.html#confval-intersphinx_mapping')
```